### PR TITLE
Add async-friendly api

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -21,7 +21,7 @@ export type Options = {
 export interface Store<State: Object> {
   get<K: $Keys<State>>(key: K): $ElementType<State, K>,
   set<K: $Keys<State>, V: $ElementType<State, K>>(key: K): (value: V) => void,
-  setFrom(Store<State> => void): void,
+  setFrom_EXPERIMENTAL(Store<State> => void): void,
   on<K: $Keys<State>>(key: K): Observable<$ElementType<State, K>>,
   onAll(): Observable<$Values<Undux<State>>>,
   getState(): $ReadOnly<State>
@@ -30,7 +30,7 @@ export interface Store<State: Object> {
 declare export class StoreSnapshot<State: Object> implements Store<State> {
   get<K: $Keys<State>>(key: K): $ElementType<State, K>,
   set<K: $Keys<State>, V: $ElementType<State, K>>(key: K): (value: V) => void,
-  setFrom(Store<State> => void): void,
+  setFrom_EXPERIMENTAL(Store<State> => void): void,
   on<K: $Keys<State>>(key: K): Observable<$ElementType<State, K>>,
   onAll(): Observable<$Values<Undux<State>>>,
   getState(): $ReadOnly<State>
@@ -39,7 +39,7 @@ declare export class StoreSnapshot<State: Object> implements Store<State> {
 declare export class StoreDefinition<State: Object> implements Store<State> {
   get<K: $Keys<State>>(key: K): $ElementType<State, K>,
   set<K: $Keys<State>, V: $ElementType<State, K>>(key: K): (value: V) => void,
-  setFrom(Store<State> => void): void,
+  setFrom_EXPERIMENTAL(Store<State> => void): void,
   on<K: $Keys<State>>(key: K): Observable<$ElementType<State, K>>,
   onAll(): Observable<$Values<Undux<State>>>,
   getCurrentSnapshot(): StoreSnapshot<State>,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -21,6 +21,7 @@ export type Options = {
 export interface Store<State: Object> {
   get<K: $Keys<State>>(key: K): $ElementType<State, K>,
   set<K: $Keys<State>, V: $ElementType<State, K>>(key: K): (value: V) => void,
+  setFrom(Store<State> => void): void,
   on<K: $Keys<State>>(key: K): Observable<$ElementType<State, K>>,
   onAll(): Observable<$Values<Undux<State>>>,
   getState(): $ReadOnly<State>
@@ -29,6 +30,7 @@ export interface Store<State: Object> {
 declare export class StoreSnapshot<State: Object> implements Store<State> {
   get<K: $Keys<State>>(key: K): $ElementType<State, K>,
   set<K: $Keys<State>, V: $ElementType<State, K>>(key: K): (value: V) => void,
+  setFrom(Store<State> => void): void,
   on<K: $Keys<State>>(key: K): Observable<$ElementType<State, K>>,
   onAll(): Observable<$Values<Undux<State>>>,
   getState(): $ReadOnly<State>
@@ -37,6 +39,7 @@ declare export class StoreSnapshot<State: Object> implements Store<State> {
 declare export class StoreDefinition<State: Object> implements Store<State> {
   get<K: $Keys<State>>(key: K): $ElementType<State, K>,
   set<K: $Keys<State>, V: $ElementType<State, K>>(key: K): (value: V) => void,
+  setFrom(Store<State> => void): void,
   on<K: $Keys<State>>(key: K): Observable<$ElementType<State, K>>,
   onAll(): Observable<$Values<Undux<State>>>,
   getCurrentSnapshot(): StoreSnapshot<State>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export type Undux<State extends object> = {
 export interface Store<State extends object> {
   get<K extends keyof State>(key: K): State[K]
   set<K extends keyof State>(key: K): (value: State[K]) => void
-  setFrom(f: (store: Store<State>) => void): void
+  setFrom_EXPERIMENTAL(f: (store: Store<State>) => void): void
   on<K extends keyof State>(key: K): Observable<State[K]>
   onAll(): Observable<Undux<State>[keyof State]>
   getState(): Readonly<State>
@@ -43,8 +43,8 @@ export class StoreSnapshot<State extends object> implements Store<State> {
   set<K extends keyof State>(key: K) {
     return this.storeDefinition.set(key)
   }
-  setFrom(f: (store: Store<State>) => void): void {
-    return this.storeDefinition.setFrom(f)
+  setFrom_EXPERIMENTAL(f: (store: Store<State>) => void): void {
+    return this.storeDefinition.setFrom_EXPERIMENTAL(f)
   }
   on<K extends keyof State>(key: K) {
     return this.storeDefinition.on(key)
@@ -116,8 +116,7 @@ export class StoreDefinition<State extends object> implements Store<State> {
   set<K extends keyof State>(key: K): (value: State[K]) => void {
     return this.setters[key]
   }
-  setFrom(f: (store: Store<State>) => void): void {
-    // TODO: Make sure it doesn't cause extra re-renders
+  setFrom_EXPERIMENTAL(f: (store: Store<State>) => void): void {
     return f(this.storeSnapshot)
   }
   getCurrentSnapshot() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export type Undux<State extends object> = {
 export interface Store<State extends object> {
   get<K extends keyof State>(key: K): State[K]
   set<K extends keyof State>(key: K): (value: State[K]) => void
-  setFrom<K extends keyof State>(key: K): (f: (value: State[K]) => State[K]) => void
+  setFrom(f: (store: Store<State>) => void): void
   on<K extends keyof State>(key: K): Observable<State[K]>
   onAll(): Observable<Undux<State>[keyof State]>
   getState(): Readonly<State>
@@ -43,8 +43,8 @@ export class StoreSnapshot<State extends object> implements Store<State> {
   set<K extends keyof State>(key: K) {
     return this.storeDefinition.set(key)
   }
-  setFrom<K extends keyof State>(key: K): (f: (value: State[K]) => State[K]) => void {
-    return this.storeDefinition.setFrom(key)
+  setFrom(f: (store: Store<State>) => void): void {
+    return this.storeDefinition.setFrom(f)
   }
   on<K extends keyof State>(key: K) {
     return this.storeDefinition.on(key)
@@ -73,10 +73,7 @@ export class StoreDefinition<State extends object> implements Store<State> {
   private alls: Emitter<Undux<State>>
   private emitter: Emitter<State>
   private setters: {
-    readonly [K in keyof State]: [
-      (f: (value: State[K]) => State[K]) => void,
-      (value: State[K]) => void
-    ]
+    readonly [K in keyof State]: (value: State[K]) => void
   }
   constructor(state: State, options: Options) {
 
@@ -95,9 +92,8 @@ export class StoreDefinition<State extends object> implements Store<State> {
     this.storeSnapshot = new StoreSnapshot(state, this)
 
     // Cache setters
-    this.setters = mapValues(state, (v, key) => {
-
-      let set = (value: typeof v) => {
+    this.setters = mapValues(state, (v, key) =>
+      (value: typeof v) => {
         let previousValue = this.storeSnapshot.get(key)
         this.storeSnapshot = new StoreSnapshot(
           Object.assign({}, this.storeSnapshot.getState(), { [key]: value }),
@@ -106,16 +102,7 @@ export class StoreDefinition<State extends object> implements Store<State> {
         this.emitter.emit(key, value)
         this.alls.emit(key, { key, previousValue, value })
       }
-
-      return [
-        (f: (value: State[typeof key]) => State[typeof key]) => {
-          let previousValue = this.storeSnapshot.get(key)
-          let value = f(previousValue)
-          return set(value)
-        },
-        set
-      ] as any
-    })
+    )
   }
   on<K extends keyof State>(key: K): Observable<State[K]> {
     return this.emitter.on(key)
@@ -127,10 +114,11 @@ export class StoreDefinition<State extends object> implements Store<State> {
     return this.storeSnapshot.get(key)
   }
   set<K extends keyof State>(key: K): (value: State[K]) => void {
-    return this.setters[key][1]
+    return this.setters[key]
   }
-  setFrom<K extends keyof State>(key: K): (f: (value: State[K]) => State[K]) => void {
-    return this.setters[key][0]
+  setFrom(f: (store: Store<State>) => void): void {
+    // TODO: Make sure it doesn't cause extra re-renders
+    return f(this.storeSnapshot)
   }
   getCurrentSnapshot() {
     return this.storeSnapshot

--- a/test/bad-cases/createConnectedStore.5.flow.js
+++ b/test/bad-cases/createConnectedStore.5.flow.js
@@ -1,0 +1,39 @@
+// @flow
+import { createConnectedStore } from '../../dist/src'
+import type { Effects, Store } from '../../dist/src'
+import * as React from 'react'
+
+type State = {|
+  a: number,
+  b: number
+|}
+
+let initialState: State = {
+  a: 1,
+  b: 2
+}
+
+let withEffects: Effects<State> = store => {
+  store.on('a').subscribe(a => a.toUpperCase())
+  return store
+}
+
+let {Container, withStore} = createConnectedStore<State>(
+  initialState,
+  withEffects
+)
+
+type Props = {|
+  store: Store<State>,
+  x: boolean
+|}
+
+let A = ({store}: Props) =>
+  store.setFrom(store => store.set('c')(2)) // Error: c is not a valid key
+
+let B = withStore(A)
+
+let StoreContainer = () =>
+  <Container>
+    <B x={true} />
+  </Container>

--- a/test/bad-cases/createConnectedStore.5.flow.js
+++ b/test/bad-cases/createConnectedStore.5.flow.js
@@ -29,7 +29,7 @@ type Props = {|
 |}
 
 let A = ({store}: Props) =>
-  store.setFrom(store => store.set('c')(2)) // Error: c is not a valid key
+  store.setFrom_EXPERIMENTAL(store => store.set('c')(2)) // Error: c is not a valid key
 
 let B = withStore(A)
 

--- a/test/bad-cases/run.sh
+++ b/test/bad-cases/run.sh
@@ -22,6 +22,7 @@
 ! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStore.2.flow.js
 ! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStore.3.flow.js
 ! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStore.4.flow.js
+! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStore.5.flow.js
 ! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStoreAs.1.flow.js
 ! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStoreAs.2.flow.js
 ! ./node_modules/.bin/flow focus-check test/bad-cases/createConnectedStoreAs.3.flow.js

--- a/test/react/createConnectedStore.tsx
+++ b/test/react/createConnectedStore.tsx
@@ -745,7 +745,7 @@ test('it should fail for async updates by default', t => {
   })
 })
 
-test('it should work for async updates using setFrom', t => {
+test('it should work for async updates using setFrom_EXPERIMENTAL', t => {
   type State = {
     as: number[]
   }
@@ -757,7 +757,7 @@ test('it should work for async updates using setFrom', t => {
   }
   class A extends React.Component<Props> {
     componentDidMount() {
-      this.props.store.setFrom(store => {
+      this.props.store.setFrom_EXPERIMENTAL(store => {
         let as = store.get('as')
         store.set('as')([...as, index++])
       })
@@ -793,7 +793,7 @@ test('it should work for async updates using setFrom', t => {
   })
 })
 
-test('setFrom should compose', t => {
+test('setFrom_EXPERIMENTAL should compose', t => {
   type State = {
     as: number[]
   }
@@ -805,12 +805,12 @@ test('setFrom should compose', t => {
   }
   class A extends React.Component<Props> {
     componentDidMount() {
-      this.props.store.setFrom(store => {
+      this.props.store.setFrom_EXPERIMENTAL(store => {
         let as = store.get('as')
         store.set('as')([...as, index++])
 
         // One more time
-        store.setFrom(store => {
+        store.setFrom_EXPERIMENTAL(store => {
           let as = store.get('as')
           store.set('as')([...as, index++])
         })
@@ -847,7 +847,7 @@ test('setFrom should compose', t => {
   })
 })
 
-test('setFrom should chain', t => {
+test('setFrom_EXPERIMENTAL should chain', t => {
   type State = {
     as: number
   }
@@ -858,13 +858,13 @@ test('setFrom should chain', t => {
   }
   class A extends React.Component<Props> {
     componentDidMount() {
-      this.props.store.setFrom(store =>
+      this.props.store.setFrom_EXPERIMENTAL(store =>
         store.set('as')(store.get('as') + 1)
       )
-      this.props.store.setFrom(store =>
+      this.props.store.setFrom_EXPERIMENTAL(store =>
         store.set('as')(store.get('as') + 1)
       )
-      this.props.store.setFrom(store =>
+      this.props.store.setFrom_EXPERIMENTAL(store =>
         store.set('as')(store.get('as') + 1)
       )
     }

--- a/test/react/createConnectedStore.tsx
+++ b/test/react/createConnectedStore.tsx
@@ -846,3 +846,47 @@ test('setFrom should compose', t => {
     t.deepEqual(store.get('as'), [0, 1, 2, 3, 4, 5])
   })
 })
+
+test('setFrom should chain', t => {
+  type State = {
+    as: number
+  }
+  let S = createConnectedStore<State>({ as: 0 })
+
+  type Props = {
+    store: Store<State>
+  }
+  class A extends React.Component<Props> {
+    componentDidMount() {
+      this.props.store.setFrom(store =>
+        store.set('as')(store.get('as') + 1)
+      )
+      this.props.store.setFrom(store =>
+        store.set('as')(store.get('as') + 1)
+      )
+      this.props.store.setFrom(store =>
+        store.set('as')(store.get('as') + 1)
+      )
+    }
+    render() {
+      return <div />
+    }
+  }
+  let A1 = S.withStore(A)
+
+  let store: Store<State>
+  let Leak = S.withStore(props => {
+    store = (props as any).store['storeDefinition']
+    return null
+  })
+
+  function C() {
+    return <S.Container>
+      <Leak />
+      <A1 />
+    </S.Container>
+  }
+  withElement(C, _ => {
+    t.deepEqual(store.get('as'), 3)
+  })
+})

--- a/test/react/createConnectedStore.tsx
+++ b/test/react/createConnectedStore.tsx
@@ -699,7 +699,7 @@ test('it should return the same value when call .get multiple times for one snap
   })
 })
 
-test.only('it should fail for async updates by default', t => {
+test('it should fail for async updates by default', t => {
   type State = {
     as: number[]
   }
@@ -745,7 +745,7 @@ test.only('it should fail for async updates by default', t => {
   })
 })
 
-test.only('it should work for async updates using setFrom', t => {
+test('it should work for async updates using setFrom', t => {
   type State = {
     as: number[]
   }
@@ -790,5 +790,59 @@ test.only('it should work for async updates using setFrom', t => {
   }
   withElement(C, _ => {
     t.deepEqual(store.get('as'), [0, 1, 2])
+  })
+})
+
+test('setFrom should compose', t => {
+  type State = {
+    as: number[]
+  }
+  let S = createConnectedStore<State>({ as: [] })
+  let index = 0
+
+  type Props = {
+    store: Store<State>
+  }
+  class A extends React.Component<Props> {
+    componentDidMount() {
+      this.props.store.setFrom(store => {
+        let as = store.get('as')
+        store.set('as')([...as, index++])
+
+        // One more time
+        store.setFrom(store => {
+          let as = store.get('as')
+          store.set('as')([...as, index++])
+        })
+      })
+    }
+    render() {
+      return <div />
+    }
+  }
+  let A1 = S.withStore(A)
+
+  function B() {
+    return <>
+      <A1 />
+      <A1 />
+      <A1 />
+    </>
+  }
+
+  let store: Store<State>
+  let Leak = S.withStore(props => {
+    store = (props as any).store['storeDefinition']
+    return null
+  })
+
+  function C() {
+    return <S.Container>
+      <Leak />
+      <B />
+    </S.Container>
+  }
+  withElement(C, _ => {
+    t.deepEqual(store.get('as'), [0, 1, 2, 3, 4, 5])
   })
 })

--- a/test/react/createConnectedStore.tsx
+++ b/test/react/createConnectedStore.tsx
@@ -757,7 +757,10 @@ test.only('it should work for async updates using setFrom', t => {
   }
   class A extends React.Component<Props> {
     componentDidMount() {
-      this.props.store.setFrom('as')(as => [...as, index++])
+      this.props.store.setFrom(store => {
+        let as = store.get('as')
+        store.set('as')([...as, index++])
+      })
     }
     render() {
       return <div />

--- a/test/react/createConnectedStore.tsx
+++ b/test/react/createConnectedStore.tsx
@@ -699,7 +699,7 @@ test('it should return the same value when call .get multiple times for one snap
   })
 })
 
-test.only('it should work for async updates', t => {
+test.only('it should fail for async updates by default', t => {
   type State = {
     as: number[]
   }
@@ -741,6 +741,51 @@ test.only('it should work for async updates', t => {
     </S.Container>
   }
   withElement(C, _ => {
-    t.deepEqual(store.get('as'), [])
+    t.deepEqual(store.get('as'), [2])
+  })
+})
+
+test.only('it should work for async updates using setFrom', t => {
+  type State = {
+    as: number[]
+  }
+  let S = createConnectedStore<State>({ as: [] })
+  let index = 0
+
+  type Props = {
+    store: Store<State>
+  }
+  class A extends React.Component<Props> {
+    componentDidMount() {
+      this.props.store.setFrom('as')(as => [...as, index++])
+    }
+    render() {
+      return <div />
+    }
+  }
+  let A1 = S.withStore(A)
+
+  function B() {
+    return <>
+      <A1 />
+      <A1 />
+      <A1 />
+    </>
+  }
+
+  let store: Store<State>
+  let Leak = S.withStore(props => {
+    store = (props as any).store['storeDefinition']
+    return null
+  })
+
+  function C() {
+    return <S.Container>
+      <Leak />
+      <B />
+    </S.Container>
+  }
+  withElement(C, _ => {
+    t.deepEqual(store.get('as'), [0, 1, 2])
   })
 })

--- a/test/test.flow.js
+++ b/test/test.flow.js
@@ -124,6 +124,12 @@ store.onAll().subscribe(_ => {
   _.value === true
 })
 
+/////////////////// setFrom ///////////////////
+
+store.setFrom(store => {
+  store.set('isTrue')(true)
+})
+
 /////////////////// connectAs ///////////////////
 
 type CombinedA = {| a: number |}

--- a/test/test.flow.js
+++ b/test/test.flow.js
@@ -124,9 +124,9 @@ store.onAll().subscribe(_ => {
   _.value === true
 })
 
-/////////////////// setFrom ///////////////////
+/////////////////// setFrom_EXPERIMENTAL ///////////////////
 
-store.setFrom(store => {
+store.setFrom_EXPERIMENTAL(store => {
   store.set('isTrue')(true)
 })
 


### PR DESCRIPTION
This PR introduces a new, experimental `setFrom` API for use with async rendering.

This is useful when multiple components might update the same state field concurrently: with `set`, the behavior is last-one wins; with `setFrom`, a new value can depend on a previous value. As with `set`, order of writes is guaranteed.

For example, say you have the following code:

```js
let x = store.get('x') // 1
store.set('x')(x + 1) // store.get('x') is now 2
store.set('x')(x + 1) // store.get('x') is still 2
store.set('x')(x + 1) // store.get('x') is still 2
```

With `setFrom`, the behavior is:

```js
let x = store.get('x') // 1
store.setFrom(store => store.set('x')(store.get('x') + 1)) // store.get('x') is now 2
store.setFrom(store => store.set('x')(store.get('x') + 1)) // store.get('x') is now 3
store.setFrom(store => store.set('x')(store.get('x') + 1)) // store.get('x') is now 4
```

A downside is that this complicates Undux by introducing a new API. It also adds overhead that comes with having to understand React's async rendering, in order to know when to use this API.