### PR TITLE
+ get/1 && set/1 accept an enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,21 @@ export class StoreSnapshot<State extends object> implements Store<State> {
     private storeDefinition: StoreDefinition<State>
   ) { }
   get<K extends keyof State>(key: K) {
+    if (Array.isArray(key)) {
+      return key.reduce((acc, key) => {
+        acc[key] = this.get(key)
+        return acc
+      }, {})
+    }
     return this.state[key]
   }
   set<K extends keyof State>(key: K) {
+    if (!Array.isArray(key) && typeof key === "object") {
+      for (const k in key) {
+        this.storeDefinition.set(k)(key[k])
+      }
+      return this.state
+    }
     return this.storeDefinition.set(key)
   }
   setFrom_EXPERIMENTAL(f: (store: Store<State>) => void): void {


### PR DESCRIPTION
Hey,

> I noticed in the source code you have `getState/1`. FYI, it isn't listed in the [API](https://undux.org/#api/get).

My use case is when I want to get multiple values from the store--I'd prefer not to have to call `store.get/1` multiple times. `getState/1` does allow for that.

There's also the "write" version of that use case: setting multiple key-value pairs in one function call, by passing an object and then merging.

I'm no expert in TypeScript, so I just added the raw code.

LMK WYT,
Alexander