### PR TITLE
Use ambiguous-object-type lint and exact-by-default syntax in index.js.flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ava": "^1.2.1",
     "awesome-typescript-loader": "^5.2.1",
     "concurrently": "^4.1.0",
-    "flow-bin": "^0.94.0",
+    "flow-bin": "^0.113.0",
     "immutable": "^4.0.0-rc.12",
     "jsdom": "^13.2.0",
     "jsdom-global": "^3.0.2",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,5 +1,7 @@
 // @flow
 
+// flowlint ambiguous-object-type:error
+
 import * as React from 'react'
 import type { Observable } from 'rxjs'
 export type Undux<State: Object> = $ObjMap<State, Lift<State>>
@@ -9,13 +11,15 @@ type Lift<State: Object> = <V>(value: V) => Lifted<State, V>
 type Lifted<State, T> = {
   key: $Keys<State>,
   previousValue: T,
-  value: T
+  value: T,
+  ...
 }
 
 export type Exactly<T> = T
 
 export type Options = {
-  isDevMode: boolean
+  isDevMode: boolean,
+  ...
 }
 
 export interface Store<State: Object> {
@@ -61,7 +65,8 @@ export type Plugin<State: Object> = (store: StoreDefinition<State>) => StoreDefi
 export type ToStore = <State>(s: State) => Store<State>
 type ToStoreDefinition = <State>(s: State) => StoreDefinition<State>
 export type EffectsAs<States: {
-  [alias: string]: any
+  [alias: string]: any,
+  ...
 }> = (stores: $ObjMap<States, ToStoreDefinition>) => $ObjMap<States, ToStoreDefinition>
 
 declare export function withLogger<State: Object>(
@@ -74,15 +79,15 @@ declare export function withReduxDevtools<State: Object>(
 
 declare export function connect<State: Object>(
   store: StoreDefinition<State>
-): <S: Store<State>, Props: {store: S}>(
+): <S: Store<State>, Props: {store: S, ...}>(
   Component: React.ComponentType<Props>
 ) =>
-  Class<React.Component<$Diff<Props, {store: S}>>>
+  Class<React.Component<$Diff<Props, {store: S, ...}>>>
 
 // connectAs
 
 declare export function connectAs<
-  Stores: {[alias: string]: Store<any>}
+  Stores: {[alias: string]: Store<any>, ...}
 >(
   stores: Stores
 ): <Props: Object>(
@@ -100,9 +105,9 @@ export type ContainerProps<State: Object> = {|
 export type Connect<State: Object> = {|
   Container: React.ComponentType<ContainerProps<State>>,
   useStore: () => Store<State>,
-  withStore: <S: Store<State>, Props: {store: S}>(
+  withStore: <S: Store<State>, Props: {store: S, ...}>(
     Component: React.ComponentType<Props>
-  ) => Class<React.Component<$Diff<Props, {store: S}>>>
+  ) => Class<React.Component<$Diff<Props, {store: S, ...}>>>
 |}
 
 declare export function createConnectedStore<State: Object>(
@@ -113,7 +118,8 @@ declare export function createConnectedStore<State: Object>(
 // createConnectedStoreAs
 
 export type ContainerPropsAs<States: {
-  [alias: string]: any
+  [alias: string]: any,
+  ...
 }> = {|
   children: React.Node,
   effects?: EffectsAs<States>,
@@ -121,7 +127,8 @@ export type ContainerPropsAs<States: {
 |}
 
 export type ConnectAs<States: {
-  [alias: string]: any
+  [alias: string]: any,
+  ...
 }> = {|
   Container: React.ComponentType<ContainerPropsAs<States>>,
   useStores: () => $ObjMap<States, ToStore>,
@@ -131,5 +138,6 @@ export type ConnectAs<States: {
 |}
 
 declare export function createConnectedStoreAs<States: {
-  [alias: string]: any
+  [alias: string]: any,
+  ...
 }>(initialStates: States, effects?: EffectsAs<States>): ConnectAs<Exactly<States>>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@ findup-sync@^2.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
-flow-bin@^0.94.0:
-  version "0.94.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
-  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
+flow-bin@^0.113.0:
+  version "0.113.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.113.0.tgz#6457d250dbc6f71ca51e75f00a96d23cde5d987a"
+  integrity sha512-76uE2LGNe50wm+Jup8Np4FBcMbyy5V2iE+K25PPIYLaEMGHrL1jnQfP9L0hTzA5oh2ZJlexRLMlaPqIYIKH9nw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Now that some projects are using exact-by-default syntax, we should change the exported flow types here to be compatible with both exact-by-default and non-exact-by-default codebases.

To do that, we can use the `ambiguous-object-type` lint, which will error on uses of `{}` without explicitly being exact `{||}` or inexact `{...}`.

To test, I ran `flow check` and made sure there were no errors in `index.js.flow`, but there were other module resolution errors.

