### PR TITLE
Upgrade CI to node 14.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.14
+      - image: cimg/node:14.21
 
     steps:
+      - run:
+          name: Node version
+          command: node -v
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
The circleci/node images have been deprecated and replaced by cimg/node according to https://circleci.com/docs/circleci-images/

Node 16 seems to be the most recent version compatible with the webpack version used here.

Node 14 is the most recent version where CI tests pass.